### PR TITLE
Don't decode text strings of UTF-8

### DIFF
--- a/Mueval/ArgsParse.hs
+++ b/Mueval/ArgsParse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Mueval.ArgsParse (Options(..), interpreterOpts, getOptions) where
 
 import Control.Monad (liftM)
@@ -103,4 +104,11 @@ header = "Usage: mueval [OPTION...] --expression EXPRESSION..."
 -- | Just give us the end result options; this parsing for
 --   us. Bonus points for handling UTF.
 getOptions :: [String] -> Either (Bool, String) Options
-getOptions = interpreterOpts . map Codec.decodeString
+getOptions = interpreterOpts . map decodeString
+
+decodeString :: String -> String
+#if __GLASGOW_HASKELL__ >= 702
+decodeString = id
+#else
+decodeString = Codec.decodeString
+#endif


### PR DESCRIPTION
It seems that getArgs returns the list of UTF-8 strings correctly on GHC-7.2.1 or later.

This patch fixes following test contained with test.sh.

> m 'let (ñ) = (+) in ñ 5 5'
