### PR TITLE
Add QuickCheck as a dependency

### DIFF
--- a/mueval.cabal
+++ b/mueval.cabal
@@ -32,7 +32,8 @@ library
         exposed-modules:     Mueval.Parallel, Mueval.Context, Mueval.Interpreter,
                              Mueval.ArgsParse, Mueval.Resources
         build-depends:       base>=4 && < 5, containers, directory, mtl>2, filepath, unix, process,
-                             hint>=0.3.1, show>=0.3, utf8-string, Cabal, extensible-exceptions, simple-reflect
+                             hint>=0.3.1, show>=0.3, utf8-string, Cabal, extensible-exceptions, simple-reflect,
+                             QuickCheck
         ghc-options:         -Wall -static
 
 executable mueval-core


### PR DESCRIPTION
Otherwise, this happens:

```
$ GHC_PACKAGE_PATH="/app/.halcyon/ghc/lib/ghc-7.8.3/package.conf.d:/app/.halcyon/sandbox/x86_64-linux-ghc-7.8.3-packages.conf.d" \
    mueval -e '1 + 1'
<no location info>:
    Could not find module âTest.QuickCheckâ
    Use -v to see a list of the files searched for.
```
