### PR TITLE
Fix build on ghc 7.0

### DIFF
--- a/Mueval/ArgsParse.hs
+++ b/Mueval/ArgsParse.hs
@@ -5,6 +5,9 @@ import Control.Monad (liftM)
 import System.Console.GetOpt
 
 import Mueval.Context (defaultModules, defaultPackages)
+#if __GLASGOW_HASKELL__ < 702
+import qualified Codec.Binary.UTF8.String as Codec (decodeString)
+#endif
 
 -- | See the results of --help for information on what each option means.
 data Options = Options

--- a/mueval.cabal
+++ b/mueval.cabal
@@ -34,6 +34,8 @@ library
         build-depends:       base>=4 && < 5, containers, directory, mtl>2, filepath, unix, process,
                              hint>=0.3.1, show>=0.3, Cabal, extensible-exceptions, simple-reflect,
                              QuickCheck
+        if impl(ghc < 7.2)
+          build-depends:     utf8-string
         ghc-options:         -Wall -static
 
 executable mueval-core


### PR DESCRIPTION
Conditionally adds utf8-string as a dependency.

There was some stray CPP left after c5267fa563bc3571e8a269f4ab750a14b5a8855b, this fixes that and doesn't pull in utf8-string on newer GHCs.

The other option would be to drop the CPP and set a `base >= 4.4` lower bound.

I revised the latest version to exclude GHC 7.0 (https://hackage.haskell.org/package/mueval-0.9.1.1.2/revisions/) so a new release is only needed if you wish to bring back GHC 7.0 compatibility.

Build matrix: http://matrix.hackage.haskell.org/package/mueval#GHC-7.0/mueval-0.9.1.1.2