### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/mueval.cabal
+++ b/mueval.cabal
@@ -22,7 +22,7 @@ description:         Mueval is a Haskell interpreter. It
 homepage:            https://github.com/gwern/mueval
 
 build-type:          Simple
-cabal-version:       >= 1.6
+cabal-version:       >= 1.8
 tested-with:         GHC==6.10.1
 
 data-files:          README.md, HCAR.tex


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: mueval.cabal:34:43: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.      
```