### PR TITLE
Remove unnecessary `extensible-exceptions` dependency

### DIFF
--- a/mueval.cabal
+++ b/mueval.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -44,7 +44,6 @@ library
     , base >=4.5 && <5
     , containers
     , directory
-    , extensible-exceptions
     , filepath
     , hint
     , mtl
@@ -67,7 +66,6 @@ executable mueval
     , base >=4.5 && <5
     , containers
     , directory
-    , extensible-exceptions
     , filepath
     , hint
     , mtl
@@ -92,7 +90,6 @@ test-suite mueval-test
     , base >=4.5 && <5
     , containers
     , directory
-    , extensible-exceptions
     , filepath
     , hint
     , mtl

--- a/package.yaml
+++ b/package.yaml
@@ -42,7 +42,6 @@ dependencies:
 - hint
 - Cabal
 - show
-- extensible-exceptions
 - simple-reflect
 - QuickCheck
 

--- a/src/Mueval/Interpreter.hs
+++ b/src/Mueval/Interpreter.hs
@@ -4,7 +4,7 @@
 -- TODO: suggest the convenience functions be put into Hint proper?
 module Mueval.Interpreter where
 
-import qualified Control.Exception.Extensible as E (SomeException (..), catch, evaluate)
+import qualified Control.Exception as E (SomeException (..), catch, evaluate)
 import Control.Monad (forM_, guard, mplus, unless, when)
 import Control.Monad.Trans (MonadIO)
 import Control.Monad.Writer (runWriterT, tell)


### PR DESCRIPTION
For `base >= 4`, `extensible-exceptions` simply reexports `Control.Exception`.